### PR TITLE
fix(service configuration): increase LimitNOFILE

### DIFF
--- a/couchdb.service
+++ b/couchdb.service
@@ -8,7 +8,7 @@ Environment=COUCHDB_VM_ARGS=/etc/couchdb/vm.args
 Environment="COUCHDB_INI_FILES=/etc/couchdb/default.ini /etc/couchdb/default.d /etc/couchdb/local.ini /etc/couchdb/local.d"
 User=couchdb
 Group=couchdb
-LimitNOFILE=8192
+LimitNOFILE=100000
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
We have following errors in couchdb log when doing heavy operations:
```
...{error,emfile}...
```
It's link to the system file handle limit, see:
https://github.com/apache/couchdb/issues/774#issuecomment-324525403

As describe in documentation, when couchdb is used with systemd,
we also need to increase the systemd service LimitNOFILE parameters:
http://docs.couchdb.org/en/stable/maintenance/performance.html#maximum-open-file-descriptors-ulimit

The above link also says: "UNIX-like systems can handle very large
numbers of file handles per process (e.g. 100000) without problem".

So I propose to change the default LimitNOFILE to the value describe
in the documentation (e.g. 100000).