### PR TITLE
Version 2.1.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,3 +45,18 @@ Clean:
  cp couchdb.service *.patch usr-bin-couchdb ~/rpmbuild/SOURCES \
    && rpmbuild -bs couchdb.spec
  mock -r epel-7-x86_64 rebuild ~/rpmbuild/SRPMS/couchdb-2.*.src.rpm
+
+Custom couch-js package
+-----------------------
+
+We need to compile and ship our own ``js`` package, because of reasons
+described at https://github.com/apache/couchdb-pkg/tree/7768c00/js.
+The SRPM can be quickly built by running:
+
+.. code:: shell
+
+ git clone git@github.com:apache/couchdb-pkg.git /tmp/couchdb-pkg
+ cd /tmp/couchdb-pkg
+ cp js/src/js185-1.0.0.tar.gz js/rpm/SOURCES/* ~/rpmbuild/SOURCES/
+ rpmbuild -bs js/rpm/SPECS/js.spec
+ mock -r epel-7-x86_64 rebuild ~/rpmbuild/SRPMS/couch-js-1.8.5-21.fc28.src.rpm

--- a/couchdb.spec
+++ b/couchdb.spec
@@ -21,6 +21,8 @@ BuildRequires: erlang-erts >= R13B
 BuildRequires: erlang-eunit >= R15B
 BuildRequires: erlang-os_mon
 BuildRequires: erlang-xmerl
+BuildRequires: gcc
+BuildRequires: gcc-c++
 BuildRequires: js-devel
 BuildRequires: libicu-devel
 

--- a/couchdb.spec
+++ b/couchdb.spec
@@ -4,8 +4,8 @@
 # http://copr-dist-git.fedorainfracloud.org/cgit/gorbyo/epel7-couchdb/couchdb.git/tree/couchdb.spec?h=epel7&id=6d5a4ac1e3f04981af41bbf6f49022754a83d416
 
 Name:          couchdb
-Version:       2.1.1
-Release:       2%{?dist}
+Version:       2.1.2
+Release:       1%{?dist}
 Summary:       A document database server, accessible via a RESTful JSON API
 Group:         Applications/Databases
 License:       Apache
@@ -26,6 +26,7 @@ BuildRequires: gcc-c++
 BuildRequires: js-devel
 BuildRequires: libicu-devel
 
+Requires: couch-js
 Requires(pre): shadow-utils
 Requires(post): systemd
 Requires(preun): systemd
@@ -102,6 +103,10 @@ getent passwd %{name} >/dev/null || \
 
 
 %changelog
+* Mon Jul 16 2018 Adrien Vergé <adrienverge@gmail.com> 2.1.2-1
+- Update to new upstream version
+- Build our custom couch-js like described on https://github.com/apache/couchdb-pkg/tree/7768c00/js
+
 * Mon Apr 9 2018 Adrien Vergé <adrienverge@gmail.com> 2.1.1-2
 - Increase number of open file descriptors
 

--- a/couchdb.spec
+++ b/couchdb.spec
@@ -3,10 +3,6 @@
 # Inspired from
 # http://copr-dist-git.fedorainfracloud.org/cgit/gorbyo/epel7-couchdb/couchdb.git/tree/couchdb.spec?h=epel7&id=6d5a4ac1e3f04981af41bbf6f49022754a83d416
 
-# To prevent installation errors that appeared since version 2.1.1
-# (file /usr/lib/.build-id/... conflicts with file from package erlang...)
-%global _build_id_links none
-
 Name:          couchdb
 Version:       2.1.1
 Release:       2%{?dist}


### PR DESCRIPTION
#### Remove "%global _build_id_links" hack

It does not seem to be needed anymore

---

#### Add C and C++ compilers to build requirements (for Fedora 29+)

Otherwise it doesn't build.
See https://pagure.io/packaging-committee/issue/490

---

#### Update to CouchDB 2.1.2 and include couch-js

We need to compile and ship our own ``js`` package, because of reasons
described at https://github.com/apache/couchdb-pkg/tree/7768c00/js.
