### PR TITLE
fix: systemd clean stop

### DIFF
--- a/couchdb.service
+++ b/couchdb.service
@@ -10,6 +10,7 @@ User=couchdb
 Group=couchdb
 LimitNOFILE=100000
 KillMode=process
+ExecStopPost=/bin/bash -c 'until /opt/couchdb/erts-*/bin/epmd -names | (! grep "^name couchdb at"); do sleep 1; done'
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
When the service is stopped and start quikcly (or restarted), it can fail, with
the following trace in logs:
```
systemd[1]: Stopping CouchDB Server...
systemd[1]: Started CouchDB Server.
systemd[1]: Starting CouchDB Server...
epmd[5249]: epmd: node name already occupied couchdb
couchdb[7152]: Protocol 'inet_tcp': the name ... seems to be in use by another Erlang node
```

[`killMode=process`] option is used so CouchDB can cleanly close is children,
But it have the side effect of letting the Erlang `epmd` deamon up, and this
one keep a `couchdb` node name just a bit too long between a start and a stop.

One proposition is to use systemd [`ExecStopPost=`] option to execute a bloking
bash command as long as `epmd` deamon return the old instance.

Trace after the change:
```
systemd[1]: Stopping CouchDB Server...
bash[14359]: name couchdb at port 36936  # command executed one time
systemd[1]: Started CouchDB Server.
systemd[1]: Starting CouchDB Server...
```

Note that I tested a case were `ExecStopPost=` block forever, and the
`systemctl stop couchdb` command block too.

[`killMode=process`]: https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=
[`ExecStopPost=`]: https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStopPost=
