### PR TITLE
feat: Improve logging when Systemd wait for CouchDB stop

### DIFF
--- a/couchdb.service
+++ b/couchdb.service
@@ -10,7 +10,7 @@ User=couchdb
 Group=couchdb
 LimitNOFILE=100000
 KillMode=process
-ExecStopPost=/bin/bash -c 'until /opt/couchdb/erts-*/bin/epmd -names | (! grep "^name couchdb at"); do sleep 1; done'
+ExecStopPost=/bin/bash -c 'until /opt/couchdb/erts-*/bin/epmd -names | (! (grep -q "^name couchdb at" && echo "CouchDB process still running...")); do sleep 1; done'
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Before the output was:
```
systemd[1]: Stopping CouchDB Server...
bash[48530]: name couchdb at port 35785
...
bash[48530]: name couchdb at port 35785
systemd[1]: couchdb.service: Succeeded.
```
After it will be:
```
systemd[1]: Stopping CouchDB Server...
bash[52578]: CouchDB process still running...
...
bash[52578]: CouchDB process still running...
systemd[1]: couchdb.service: Succeeded.
```

Tested locally by overriding my `/usr/lib/systemd/system/couchdb.service` file.

Thanks Adrien for the idea!