### PR TITLE
Update to new upstream version & use Erlang 24.1.7 for all targets

### DIFF
--- a/couchdb.spec
+++ b/couchdb.spec
@@ -7,8 +7,8 @@
 %undefine _missing_build_ids_terminate_build
 
 Name:          couchdb
-Version:       3.2.1
-Release:       2%{?dist}
+Version:       3.2.2
+Release:       1%{?dist}
 Summary:       A document database server, accessible via a RESTful JSON API
 Group:         Applications/Databases
 License:       Apache
@@ -17,11 +17,7 @@ Source0:       http://apache.mirrors.ovh.net/ftp.apache.org/dist/couchdb/source/
 Source1:       %{name}.service
 Source2:       usr-bin-couchdb
 
-%if 0%{?el8}
 BuildRequires: erlang = 24.1.7
-%else
-BuildRequires: erlang >= 23, erlang < 25
-%endif
 BuildRequires: gcc
 BuildRequires: gcc-c++
 BuildRequires: libicu-devel
@@ -116,6 +112,10 @@ getent passwd %{name} >/dev/null || \
 
 
 %changelog
+* Tue Apr 19 2022 Hoël Iris <hoel.iris@gmail.com> 3.2.2-1
+- Update to new upstream version
+- Use Erlang = 24.1.7 (previously: >= 23, < 25) for Fedora 35+
+
 * Thu Nov 25 2021 Baptiste Ravier <baptiste.ravier@gmail.com> 3.2.1-2
 - Use Erlang >= 23 (previously: >= 22) for CentOS 8 and Fedora 34+
 


### PR DESCRIPTION
With the precedent Erlang dependency for Fedora, i.e. `>= 23, < 25`, build
for Fedora 35 failed with error:
```
==> rel (generate)
ERROR: Unable to generate spec: read file info /usr/lib64/erlang/lib/dialyzer-4.4.4/doc/chunks failed
ERROR: Unexpected error: rebar_abort
ERROR: generate failed while processing /builddir/build/BUILD/apache-couchdb-3.2.2/rel: rebar_abort
make: *** [Makefile:381: release] Error 1
```
I think it's due to a change in Erlang between version 24.1.7 and the current most
recent, version 24.3.3.
On Fedora 35 we could have used the official Erlang 24.1.4 which is still
available but that doesn't work for Fedora 36, so let's just use our own build
Erlang 24.1.7 for Epel and both Fedora (available in adrienverge copr).