### PR TITLE
Update to CouchDB 3.5.0

### DIFF
--- a/couchdb.spec
+++ b/couchdb.spec
@@ -3,11 +3,9 @@
 # Do not include debuginfo symlinks from /usr/lib/.build-id because they
 # conflict with other erlang packages:
 %define _build_id_links none
-# Needed to avoid build error: No build ID note found in [...].o
-%undefine _missing_build_ids_terminate_build
 
 Name:          couchdb
-Version:       3.4.1
+Version:       3.5.0
 Release:       1%{?dist}
 Summary:       A document database server, accessible via a RESTful JSON API
 Group:         Applications/Databases
@@ -72,10 +70,6 @@ mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
 
 rmdir %{buildroot}/opt/couchdb/var/log %{buildroot}/opt/couchdb/var
 
-# Added by Adrien, because /usr/lib/rpm/check-rpaths complained about openssl.
-# Other option: try %global __brp_check_rpaths %{nil}
-export QA_RPATHS=$(( 0x0001|0x0002 ))
-
 
 %pre
 getent group %{name} >/dev/null || groupadd -r %{name}
@@ -109,6 +103,9 @@ getent passwd %{name} >/dev/null || \
 
 
 %changelog
+* Tue May 06 2025 Adrien Vergé 3.5.0-1
+- Update to CouchDB 3.5.0
+
 * Tue Oct 15 2024 Adrien Vergé 3.4.1-1
 - Update to CouchDB 3.4.1 + QuickJS + Erlang 26 + other changes
 

--- a/erlang-doc-fix-missing-chunks.spec
+++ b/erlang-doc-fix-missing-chunks.spec
@@ -1,5 +1,5 @@
 Name:           erlang-doc-fix-missing-chunks
-Version:        26.2.5.8
+Version:        26.2.5.11
 Release:        1%{?dist}
 Summary:        Fix missing chunks directories
 License:        GPL-3.0-or-later
@@ -28,6 +28,9 @@ done
 %{_datarootdir}/doc/erlang-%{version}/lib
 
 %changelog
+* Tue May 06 2025 Adrien Vergé 26.2.5.11-1
+- Update for latest Fedora 41 and 42, which have Erlang 26.2.5.11
+
 * Wed Feb 19 2025 Adrien Vergé 26.2.5.8-1
 - Update for Fedora 42 (beta) and 43 (rawhide), which have Erlang 26.2.5.8
 


### PR DESCRIPTION
Changes:

- Update CouchDB to new version 3.5.0.

- Update erlang-doc-fix-missing-chunks to match Erlang version 26.2.5.11 on Fedora 41 and 42, and version 26.2.5.9 on Fedora rawhide (strangely).

- Remove `%undefine _missing_build_ids_terminate_build`, which does not seem needed anymore.

- Remove `export QA_RPATHS=$(( 0x0001|0x0002 ))`, which does not seem needed anymore.