### PR TITLE
Use systemd-sysusers for user 'couchdb' and drop group 'couchdb'

### DIFF
--- a/couchdb.sysusers
+++ b/couchdb.sysusers
@@ -1,0 +1,2 @@
+#Type Name    ID GECOS                         Home directory   Shell
+u     couchdb -  "Privilege-separated CouchDB" /var/lib/couchdb -


### PR DESCRIPTION
Allocating users and groups using systemd is the new recommended way for RPM packages [^1]. In the case of CouchDB, the group didn't seem necessary to me, so this commit removes it.

This commit solves the problem encountered when trying to upgrade from Fedora 42 to 43 using command line:

    Problem 1: problem with installed package
    - couchdb-3.5.0-1.fc42.x86_64 does not belong to a distupgrade repository
    - nothing provides group(couchdb) needed by couchdb-3.5.0-1.fc43.x86_64 from copr:copr.fedorainfracloud.org:adrienverge:couchdb
    - nothing provides user(couchdb) needed by couchdb-3.5.0-1.fc43.x86_64 from copr:copr.fedorainfracloud.org:adrienverge:couchdb

To make this commit, I looked at how it was done for RPM packages of famous servers like haproxy [^2], nginx [^3] and openssh-server [^4].

I tested that a CouchDB installation works fine on a Fedora 42 laptop and a Rocky Linux 9 server.

[^1]: https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/
[^2]: https://gitlab.com/redhat/centos-stream/rpms/haproxy/-/commit/51c4b02cd6d2ca0cb67c6b0616b91b11438efa1b
[^3]: https://src.fedoraproject.org/rpms/nginx/c/02e68096adf23a30de0f748e0a0e2aa40d6f0af2
[^4]: https://src.fedoraproject.org/rpms/openssh/c/26c275d66ed66ddc954f477346454eaa94eec635