### PR TITLE
Update for Fedora 44 (in beta / final freeze)

### DIFF
--- a/erlang-doc-fix-missing-chunks.spec
+++ b/erlang-doc-fix-missing-chunks.spec
@@ -1,5 +1,5 @@
 Name:           erlang-doc-fix-missing-chunks
-Version:        26.2.5.15
+Version:        26.2.5.19
 Release:        1%{?dist}
 Summary:        Fix missing chunks directories
 License:        GPL-3.0-or-later
@@ -28,6 +28,13 @@ done
 %{_datarootdir}/doc/erlang-%{version}/lib
 
 %changelog
+* Fri Apr 17 2026 Adrien Vergé 26.2.5.19-1
+- Update for Fedora 43 and 45 (rawhide), which have Erlang 26.2.5.19, but not
+  Fedora 44 which is stuck on 26.2.5.18 (probably because in final freeze)
+
+* Fri Apr 17 2026 Adrien Vergé 26.2.5.18-1
+- Update for Fedora 44 (in beta), which has Erlang 26.2.5.18
+
 * Wed Oct 29 2025 Adrien Vergé 26.2.5.15-1
 - Update for Fedora 43 and 44 (rawhide), which have Erlang 26.2.5.15
 


### PR DESCRIPTION
Like last times, I had to:
- build quickjs
- build erlang-doc-fix-missing-chunks after updating it for the currently available Erlang versions in Fedora
- rebuild couchdb

Today I couldn't build any packages for EPEL 9 : they all failed with a "GPG check FAILED" error:

    Importing GPG key 0x05707A62:
     Userid     : ""
     Fingerprint: FCD3 55B3 0570 7A62 DA14 3AB6 E422 397E 50FE 8467 A2A9 5343 D246 D627 6AFE DF8F
     From       : /usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat9-PQC-release
    error: Certificate FCD355B305707A62:
      Policy rejects FCD355B305707A62: No binding signature at time 2026-04-17T06:54:02Z

This kind of infrastructure error is usually temporary, and we already have working builds for EPEL 9, so nevermind.

I still couldn't build package couchdb for EPEL 10, because:

    No matching package to install: 'erlang >= 26'

https://copr.fedorainfracloud.org/coprs/adrienverge/couchdb/builds/